### PR TITLE
Add min perl version.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ my(%params) =
 	DISTNAME  => 'Tree-Persist',
 	NAME      => 'Tree::Persist',
 	LICENSE   => 'artistic_2',
+        MIN_PERL_VERSION => 5.006,
 	PL_FILES  => {},
 	PREREQ_PM =>
 	{


### PR DESCRIPTION
Hi Ron, please review the above change.

As per CPANTS:

This distribution does not declare the minimum perl version in META.yml.

Many Thanks.
Best Regards,
Mohammad S Anwar
